### PR TITLE
fix typo in README code sample

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ function build(event, project) {
 }
 
 function runSuite(e, p) {
-  var check = new Check(e, p, build());
+  var check = new Check(e, p, build(e, p));
   check.run();
 }
 


### PR DESCRIPTION
I think the two params to `build()` were accidentally omitted. Since users are likely to copy/paste this, we should probably fix even though it makes no functional difference.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>