### PR TITLE
feat(kind.ts): add ability to set k8s version on a KindJob

### DIFF
--- a/src/kind.ts
+++ b/src/kind.ts
@@ -3,11 +3,21 @@ import { Job } from "@brigadecore/brigadier";
 export const kindJobImage = "radumatei/golang-kind:1.11-0.4";
 
 export class KindJob extends Job {
-    constructor(name: string, image?: string) {
+    kubernetesVersion: String;
+
+    constructor(name: string, image?: string, kubernetesVersion?: string) {
         if (image == undefined) {
             image = kindJobImage;
         }
         super(name, image);
+
+        if (kubernetesVersion == undefined) {
+          // set a default for the kind cluster version
+          // must be supported by the kind version in the default kindJobImage used
+          this.kubernetesVersion = "v1.15.3";
+        } else {
+          this.kubernetesVersion = kubernetesVersion;
+        }
 
         // kind needs to run as a privileged pod
         this.privileged = true;
@@ -62,7 +72,7 @@ export class KindJob extends Job {
             "trap 'kind delete cluster' EXIT",
             "dockerd-entrypoint.sh &",
             "sleep 20",
-            "kind create cluster --wait 300s",
+            `kind create cluster --image kindest/node:${this.kubernetesVersion} --wait 300s`,
             `export KUBECONFIG="$(kind get kubeconfig-path)"`,
             // this pod is running inside a Kubernetes cluster
             // unset environment variables pointing to the host cluster

--- a/test/kind.ts
+++ b/test/kind.ts
@@ -23,6 +23,18 @@ describe("when creating a new Kind job", () => {
         assert.equal(kind.image, "my-custom-kind-image");
     });
 
+    it("without a kubernetes version, the default value is used", () => {
+      let kind = new KindJob("kind", "my-custom-kind-image");
+
+      assert.equal(kind.kubernetesVersion, "v1.15.3");
+    });
+
+    it("when a kubernetes version is passed, the value is used", () => {
+      let kind = new KindJob("kind", "my-custom-kind-image", "v1.0.0");
+
+      assert.equal(kind.kubernetesVersion, "v1.0.0");
+    });
+
     it("job is privileged, with right number of pre-defined tasks", () => {
         let kind = new KindJob("kind");
 


### PR DESCRIPTION
Add the ability to set a particular k8s version for the kind cluster created by a KindJob.

Hoping to utilize this capability in Brigade's e2e tests to have more control over the kind k8s version.