### PR TITLE
Update package version to 0.5.0 in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ To add this package, [use the `brigade.json` file][brigade-json] in the reposito
 ```json
 {
   "dependencies": {
-    "@brigadecore/brigade-utils": "0.4.1"
+    "@brigadecore/brigade-utils": "0.5.0"
   }
 }
 ```


### PR DESCRIPTION
The readme still points to the previous version - this commit updates it to 0.5.0 (see https://www.npmjs.com/package/@brigadecore/brigade-utils)
